### PR TITLE
feat: version command, release pipeline, and CI improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binaries
+        run: |
+          VERSION=${{ github.ref_name }}
+          LDFLAGS="-X main.version=${VERSION}"
+
+          GOOS=linux  GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o guard-sh-linux-amd64  .
+          GOOS=linux  GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o guard-sh-linux-arm64  .
+          GOOS=darwin GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o guard-sh-darwin-amd64 .
+          GOOS=darwin GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o guard-sh-darwin-arm64 .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            guard-sh-linux-amd64
+            guard-sh-linux-arm64
+            guard-sh-darwin-amd64
+            guard-sh-darwin-arm64

--- a/help.go
+++ b/help.go
@@ -54,4 +54,8 @@ func runHelp() {
 	// Config
 	fmt.Printf("  %s\n", b("config"))
 	fmt.Printf("  %s\n\n", d("~/.config/guard-sh/config.yaml — providers, API keys, whitelist, cache, timeout"))
+
+	// Version
+	fmt.Printf("  %s\n", b("version"))
+	fmt.Printf("  %s %s\n\n", c("guard-sh version"), d("print version"))
 }

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ import (
 //go:embed prompt.txt
 var defaultPrompt string
 
+var version = "dev"
+
 const (
 	reset  = "\033[0m"
 	bold   = "\033[1m"
@@ -277,6 +279,11 @@ func main() {
 
 	if len(os.Args) >= 2 && os.Args[1] == "help" {
 		runHelp()
+		return
+	}
+
+	if len(os.Args) >= 2 && os.Args[1] == "version" {
+		fmt.Println(version)
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Adds `guard-sh version` command (version embedded at build time via ldflags)
- Adds release pipeline that builds Linux/macOS binaries and publishes GitHub Releases on `v*` tags
- Adds comprehensive tests for guard, cache, config, and llm/multi packages
- Adds GitHub Actions CI pipeline that runs on PRs to main

## Test plan

- [ ] CI pipeline geçiyor mu kontrol et
- [ ] Merge sonrası `v0.1.0` tag atılacak, release pipeline tetiklenecek

🤖 Generated with [Claude Code](https://claude.ai/claude-code)