### PR TITLE
feat: add Ollama provider support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ There is no Makefile.
 ## CLI subcommands
 
 ```
-guard-sh on / off               enable/disable for current session (handled by shell hook)
+guard-sh on / off                   enable/disable for current session (handled by shell hook)
 guard-sh on --global / off --global   auto-enable/disable in every new terminal
 guard-sh status                 show session/global state, config, timeout, cache, providers, whitelist
 guard-sh check "<cmd>"          core check — exit 0 if safe, exit 1 with warning if risky
@@ -67,7 +67,7 @@ shell command typed
 
 - **`internal/guard/`** — core logic: whitelist matching, cache lookup, LLM dispatch, command parsing (handles `&&`, `||`, `;`, `|`, subshells, variable assignments)
 - **`internal/llm/multi.go`** — tries providers in `provider_order` config; fails open (allows command) if all fail
-- **`internal/llm/{claude,gemini,openai,deepseek}/`** — one file per provider, each makes HTTP POST to its API; all implement the same `Provider` interface
+- **`internal/llm/{claude,gemini,openai,deepseek,ollama}/`** — one file per provider, each makes HTTP POST to its API; all implement the same `Provider` interface. Ollama uses `host` instead of `api_key` and hits a local endpoint (`/api/chat`).
 - **`internal/cache/`** — LRU cache persisted to `~/.config/guard-sh/cache.json`
 - **`internal/config/`** — YAML config loader from `~/.config/guard-sh/config.yaml`
 

--- a/README.org
+++ b/README.org
@@ -30,6 +30,7 @@ Commands in your *whitelist* skip the LLM entirely.
   - DeepSeek ([[https://platform.deepseek.com]])
   - OpenAI ([[https://platform.openai.com]])
   - Claude ([[https://console.anthropic.com]])
+  - Ollama (local, no API key required — [[https://ollama.com]])
 
 * Requirements
   :PROPERTIES:
@@ -38,7 +39,7 @@ Commands in your *whitelist* skip the LLM entirely.
 
 - Go 1.22+
 - bash or zsh
-- API key(s) for one or more of the LLMs listed under the [[#supported-llms][Supported LLMs]] section.
+- API key(s) for one or more of the cloud LLMs listed above, *or* a running [[https://ollama.com][Ollama]] instance for fully local operation.
 
 * Installation
   :PROPERTIES:
@@ -94,21 +95,25 @@ An example config file is as follows:
 #+begin_src yaml
 # Providers are tried in order. If one fails, the next is used.
 provider_order:
-  - openai
+  - ollama
   - gemini
   - deepseek
+  - openai
   - claude
 
 providers:
-  openai:
-    api_key: YOUR_OPENAI_KEY
-    model: gpt-4o-mini                    # optional, this is the default
+  ollama:
+    host: http://localhost:11434/api/chat # optional, this is the default
+    model: llama3.2                       # optional, this is the default
   gemini:
     api_key: YOUR_GEMINI_KEY
     model: gemini-3.1-flash-lite-preview  # optional, this is the default
   deepseek:
     api_key: YOUR_DEEPSEEK_KEY
     model: deepseek-chat                  # optional, this is the default
+  openai:
+    api_key: YOUR_OPENAI_KEY
+    model: gpt-4o-mini                    # optional, this is the default
   claude:
     api_key: YOUR_ANTHROPIC_KEY
     model: claude-haiku-4-5-20251001      # optional, this is the default
@@ -297,7 +302,7 @@ guard-sh provider remove   # interactively remove a provider
 guard-sh provider order    # interactively reorder providers
 #+end_src
 
-~provider add~ walks you through selecting a provider, picking a model, and entering an API key. The provider is saved to your config and added to ~provider_order~ automatically.
+~provider add~ walks you through selecting a provider, picking a model, and entering an API key (or a full chat endpoint URL for Ollama, e.g. ~http://localhost:11434/api/chat~). The provider is saved to your config and added to ~provider_order~ automatically.
 
 ~provider remove~ lists your configured providers and removes the one you select.
 

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -15,7 +15,7 @@ import (
 )
 
 var knownProviders = map[string]bool{
-	"gemini": true, "claude": true, "openai": true, "deepseek": true,
+	"gemini": true, "claude": true, "openai": true, "deepseek": true, "ollama": true,
 }
 
 func runHealthcheck() {
@@ -53,12 +53,17 @@ func runHealthcheck() {
 		p := cfg.Providers[name]
 		apiKey := ""
 		model := ""
+		host := ""
 		if p != nil {
 			apiKey = p.APIKey
 			model = p.Model
+			host = p.Host
 		}
 		if model == "" {
 			model = config.DefaultModel(name)
+		}
+		if host == "" {
+			host = config.DefaultHost(name)
 		}
 
 		nameCol := fmt.Sprintf("%-10s", name)
@@ -71,7 +76,7 @@ func runHealthcheck() {
 			continue
 		}
 
-		if apiKey == "" {
+		if apiKey == "" && name != "ollama" {
 			fmt.Printf("  %s%s%s  %s%s%s  %s✗ api_key not set%s\n",
 				cyan, nameCol, reset, dim, modelCol, reset, red, reset)
 			continue
@@ -88,6 +93,8 @@ func runHealthcheck() {
 			checkErr = healthOpenAI(ctx, hc, apiKey, model)
 		case "deepseek":
 			checkErr = healthDeepSeek(ctx, hc, apiKey, model)
+		case "ollama":
+			checkErr = healthOllama(ctx, hc, host)
 		}
 		ms := time.Since(start).Milliseconds()
 
@@ -120,6 +127,23 @@ func runHealthcheck() {
 	}
 
 	fmt.Println()
+}
+
+// healthOllama calls the Ollama tags endpoint to verify the server is running.
+func healthOllama(ctx context.Context, hc *http.Client, host string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ollamaBase(host)+"/api/tags", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	return apiError(resp)
 }
 
 // healthGemini calls the Gemini model info endpoint (no tokens).

--- a/help.go
+++ b/help.go
@@ -40,7 +40,7 @@ func runHelp() {
 
 	// Provider
 	fmt.Printf("  %s\n", b("provider"))
-	fmt.Printf("  %s %s\n", c("guard-sh provider add"), d("interactively add a provider (select model, enter API key)"))
+	fmt.Printf("  %s %s\n", c("guard-sh provider add"), d("interactively add a provider (API key for cloud, full chat URL for Ollama)"))
 	fmt.Printf("  %s %s\n", c("guard-sh provider remove"), d("interactively remove a configured provider"))
 	fmt.Printf("  %s %s\n\n", c("guard-sh provider order"), d("interactively reorder providers with arrow keys"))
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 type ProviderConfig struct {
 	APIKey string `yaml:"api_key"`
 	Model  string `yaml:"model"`
+	Host   string `yaml:"host"`
 }
 
 type Config struct {
@@ -29,11 +30,14 @@ func (c *Config) Get(name string) (*ProviderConfig, error) {
 	if !ok {
 		return nil, fmt.Errorf("provider %q not found in config", name)
 	}
-	if p.APIKey == "" {
+	if p.APIKey == "" && name != "ollama" {
 		return nil, fmt.Errorf("api_key is not set for provider %q", name)
 	}
 	if p.Model == "" {
 		p.Model = DefaultModel(name)
+	}
+	if p.Host == "" {
+		p.Host = DefaultHost(name)
 	}
 	return p, nil
 }
@@ -359,7 +363,74 @@ func DefaultModel(provider string) string {
 		return "gpt-4o-mini"
 	case "deepseek":
 		return "deepseek-chat"
+	case "ollama":
+		return "llama3.2"
 	default:
 		return ""
 	}
+}
+
+func DefaultHost(provider string) string {
+	switch provider {
+	case "ollama":
+		return "http://localhost:11434/api/chat"
+	default:
+		return ""
+	}
+}
+
+// AddOllamaProvider adds or updates the ollama provider entry in config (full URL + model, no api_key).
+func AddOllamaProvider(host, model string) error {
+	cfgPath := filepath.Join(Dir(), "config.yaml")
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return fmt.Errorf("config not found at %s", cfgPath)
+	}
+	lines := strings.Split(string(data), "\n")
+	lines = addToProviderOrder(lines, "ollama")
+	lines = upsertOllamaBlock(lines, host, model)
+	return os.WriteFile(cfgPath, []byte(strings.Join(lines, "\n")), 0600)
+}
+
+func upsertOllamaBlock(lines []string, host, model string) []string {
+	start, end := findProviderBlock(lines, "ollama")
+	newBlock := []string{
+		"  ollama:",
+		"    host: " + host,
+		"    model: " + model,
+	}
+	if start >= 0 {
+		result := make([]string, 0, len(lines))
+		result = append(result, lines[:start]...)
+		result = append(result, newBlock...)
+		result = append(result, lines[end:]...)
+		return result
+	}
+	// Insert at end of providers section
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "providers:" || strings.HasPrefix(trimmed, "providers:") {
+			if trimmed != "providers:" {
+				lines[i] = "providers:"
+			}
+			j := i + 1
+			for j < len(lines) {
+				l := lines[j]
+				if l != "" && !strings.HasPrefix(l, " ") {
+					break
+				}
+				j++
+			}
+			for j > i+1 && strings.TrimSpace(lines[j-1]) == "" {
+				j--
+			}
+			insert := append([]string{""}, newBlock...)
+			result := make([]string, 0, len(lines)+len(insert))
+			result = append(result, lines[:j]...)
+			result = append(result, insert...)
+			result = append(result, lines[j:]...)
+			return result
+		}
+	}
+	return lines
 }

--- a/internal/llm/ollama/ollama.go
+++ b/internal/llm/ollama/ollama.go
@@ -1,0 +1,104 @@
+package ollama
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const defaultURL = "http://localhost:11434/api/chat"
+
+// Client implements guard.Provider using the Ollama local API.
+type Client struct {
+	url   string
+	model string
+	http  *http.Client
+}
+
+func New(url, model string) *Client {
+	if url == "" {
+		url = defaultURL
+	}
+	return &Client{
+		url:   url,
+		model: model,
+		http:  &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+type requestBody struct {
+	Model    string    `json:"model"`
+	Messages []message `json:"messages"`
+	Stream   bool      `json:"stream"`
+	Options  options   `json:"options"`
+}
+
+type message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type options struct {
+	Temperature float64 `json:"temperature"`
+	NumPredict  int     `json:"num_predict"`
+}
+
+type responseBody struct {
+	Message struct {
+		Content string `json:"content"`
+	} `json:"message"`
+}
+
+func (c *Client) Query(ctx context.Context, systemPrompt, command string) (string, error) {
+	payload := requestBody{
+		Model: c.model,
+		Messages: []message{
+			{Role: "system", Content: systemPrompt},
+			{Role: "user", Content: command},
+		},
+		Stream: false,
+		Options: options{
+			Temperature: 0,
+			NumPredict:  150,
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.url, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("ollama HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+
+	var result responseBody
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+
+	text := strings.TrimSpace(result.Message.Content)
+	if text == "" {
+		return "OK", nil
+	}
+	return text, nil
+}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Berdan/guard-sh/internal/llm/claude"
 	"github.com/Berdan/guard-sh/internal/llm/deepseek"
 	"github.com/Berdan/guard-sh/internal/llm/gemini"
+	"github.com/Berdan/guard-sh/internal/llm/ollama"
 	"github.com/Berdan/guard-sh/internal/llm/openai"
 )
 
@@ -349,6 +350,8 @@ func main() {
 			provider = deepseek.New(p.APIKey, p.Model)
 		case "openai":
 			provider = openai.New(p.APIKey, p.Model)
+		case "ollama":
+			provider = ollama.New(p.Host, p.Model)
 		default:
 			fmt.Fprintf(os.Stderr, "guard-sh: unknown provider %q\n", name)
 			os.Exit(0) // fail open

--- a/provider.go
+++ b/provider.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
 	"strconv"
@@ -165,7 +166,7 @@ func runProviderAdd() {
 
 	// Step 1: select provider
 	fmt.Printf("\n  %sprovider%s\n\n", bold, reset)
-	names := []string{"gemini", "claude", "openai", "deepseek"}
+	names := []string{"gemini", "claude", "openai", "deepseek", "ollama"}
 
 	cfg, _ := config.Load()
 	configured := map[string]bool{}
@@ -188,38 +189,70 @@ func runProviderAdd() {
 	}
 	name := names[choice-1]
 
-	// Step 2: API key — validate by fetching models, retry on auth error
-	fmt.Printf("\n  %sapi key%s %s(%s)%s\n\n", bold, reset, dim, name, reset)
-	var apiKey string
+	// Step 2: API key (or host for ollama) — validate by fetching models
+	var apiKey, host string
 	var models []string
-	for {
-		fmt.Printf("  %s>%s ", dim, reset)
-		line, _ := reader.ReadString('\n')
-		apiKey = strings.TrimSpace(line)
-		if apiKey == "" {
-			fmt.Printf("  %s✗ api key cannot be empty%s\n\n", red, reset)
-			continue
-		}
 
-		fmt.Printf("  %svalidating...%s", dim, reset)
-		fetched, fetchErr := fetchModels(name, apiKey)
-		fmt.Printf("\r%s\r", strings.Repeat(" ", 30))
+	if name == "ollama" {
+		fmt.Printf("\n  %surl%s %s(default: %s)%s\n\n", bold, reset, dim, config.DefaultHost("ollama"), reset)
+		for {
+			fmt.Printf("  %s> (ENTER for default)  %s", dim, reset)
+			line, _ := reader.ReadString('\n')
+			host = strings.TrimSpace(line)
+			if host == "" {
+				host = config.DefaultHost("ollama")
+			}
+			if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
+				host = "http://" + host
+			}
 
-		if fetchErr != nil {
-			if isAuthError(fetchErr) {
-				fmt.Printf("  %s✗ invalid API key, try again%s\n\n", red, reset)
+			fmt.Printf("  %sconnecting...%s", dim, reset)
+			fetched, fetchErr := fetchModels(name, host)
+			fmt.Printf("\r%s\r", strings.Repeat(" ", 30))
+
+			if fetchErr != nil {
+				fmt.Printf("  %s✗ could not reach ollama (%s), try again%s\n\n", red, fetchErr.Error(), reset)
 				continue
 			}
-			// Non-auth error (network, etc.) — fall back to hard-coded list
-			fmt.Printf("  %s⚠ could not fetch models (%s), using default list%s\n", red, fetchErr.Error(), reset)
-			models = providerModelsFallback[name]
-		} else if len(fetched) == 0 {
-			fmt.Printf("  %s⚠ no models returned, using default list%s\n", dim, reset)
-			models = providerModelsFallback[name]
-		} else {
-			models = fetched
+			if len(fetched) == 0 {
+				fmt.Printf("  %s⚠ no models found, using default list%s\n", dim, reset)
+				models = providerModelsFallback[name]
+			} else {
+				models = fetched
+			}
+			break
 		}
-		break
+	} else {
+		fmt.Printf("\n  %sapi key%s %s(%s)%s\n\n", bold, reset, dim, name, reset)
+		for {
+			fmt.Printf("  %s>%s ", dim, reset)
+			line, _ := reader.ReadString('\n')
+			apiKey = strings.TrimSpace(line)
+			if apiKey == "" {
+				fmt.Printf("  %s✗ api key cannot be empty%s\n\n", red, reset)
+				continue
+			}
+
+			fmt.Printf("  %svalidating...%s", dim, reset)
+			fetched, fetchErr := fetchModels(name, apiKey)
+			fmt.Printf("\r%s\r", strings.Repeat(" ", 30))
+
+			if fetchErr != nil {
+				if isAuthError(fetchErr) {
+					fmt.Printf("  %s✗ invalid API key, try again%s\n\n", red, reset)
+					continue
+				}
+				// Non-auth error (network, etc.) — fall back to hard-coded list
+				fmt.Printf("  %s⚠ could not fetch models (%s), using default list%s\n", red, fetchErr.Error(), reset)
+				models = providerModelsFallback[name]
+			} else if len(fetched) == 0 {
+				fmt.Printf("  %s⚠ no models returned, using default list%s\n", dim, reset)
+				models = providerModelsFallback[name]
+			} else {
+				models = fetched
+			}
+			break
+		}
 	}
 
 	// Step 4: select model
@@ -255,8 +288,14 @@ func runProviderAdd() {
 	}
 
 	// Step 5: save
-	if err := config.AddProvider(name, apiKey, model); err != nil {
-		fmt.Fprintf(os.Stderr, "guard-sh: %v\n", err)
+	var saveErr error
+	if name == "ollama" {
+		saveErr = config.AddOllamaProvider(host, model)
+	} else {
+		saveErr = config.AddProvider(name, apiKey, model)
+	}
+	if saveErr != nil {
+		fmt.Fprintf(os.Stderr, "guard-sh: %v\n", saveErr)
 		os.Exit(1)
 	}
 
@@ -320,6 +359,7 @@ var providerModelsFallback = map[string][]string{
 	"claude":   {"claude-haiku-4-5-20251001", "claude-sonnet-4-6", "claude-opus-4-6"},
 	"openai":   {"gpt-4o-mini", "gpt-4o", "gpt-4-turbo", "o1-mini"},
 	"deepseek": {"deepseek-chat", "deepseek-reasoner"},
+	"ollama":   {"llama3.2", "llama3.1", "mistral", "gemma3", "phi4"},
 }
 
 func isAuthError(err error) bool {
@@ -327,19 +367,23 @@ func isAuthError(err error) bool {
 	return strings.Contains(s, "HTTP 400") || strings.Contains(s, "HTTP 401") || strings.Contains(s, "HTTP 403")
 }
 
-func fetchModels(name, apiKey string) ([]string, error) {
+// fetchModels fetches available models for a provider.
+// For ollama, the second argument is the host URL instead of an API key.
+func fetchModels(name, apiKeyOrHost string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	hc := &http.Client{Timeout: 10 * time.Second}
 	switch name {
 	case "gemini":
-		return fetchGeminiModels(ctx, hc, apiKey)
+		return fetchGeminiModels(ctx, hc, apiKeyOrHost)
 	case "claude":
-		return fetchClaudeModels(ctx, hc, apiKey)
+		return fetchClaudeModels(ctx, hc, apiKeyOrHost)
 	case "openai":
-		return fetchOpenAIModels(ctx, hc, apiKey)
+		return fetchOpenAIModels(ctx, hc, apiKeyOrHost)
 	case "deepseek":
-		return fetchDeepSeekModels(ctx, hc, apiKey)
+		return fetchDeepSeekModels(ctx, hc, apiKeyOrHost)
+	case "ollama":
+		return fetchOllamaModels(ctx, hc, apiKeyOrHost)
 	}
 	return nil, fmt.Errorf("unknown provider")
 }
@@ -433,6 +477,41 @@ func fetchOpenAIModels(ctx context.Context, hc *http.Client, apiKey string) ([]s
 		}
 	}
 	sort.Strings(models)
+	return models, nil
+}
+
+func ollamaBase(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	return u.Scheme + "://" + u.Host
+}
+
+func fetchOllamaModels(ctx context.Context, hc *http.Client, rawURL string) ([]string, error) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ollamaBase(rawURL)+"/api/tags", nil)
+	resp, err := hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, apiError(resp)
+	}
+	var result struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	models := make([]string, 0, len(result.Models))
+	for _, m := range result.Models {
+		// Strip ":latest" suffix for cleaner display
+		name := strings.TrimSuffix(m.Name, ":latest")
+		models = append(models, name)
+	}
 	return models, nil
 }
 


### PR DESCRIPTION
## Summary

- Adds Ollama as a local LLM provider — no API key required
- Provider is configured with a single chat endpoint URL (default: `http://localhost:11434/api/chat`)
- `guard-sh provider add` interactively asks for the URL, retries on connection failure
- Healthcheck validates the Ollama server via `/api/tags`
- Updated README, help, and CLAUDE.md

## Test plan

- [ ] `guard-sh provider add` → select ollama → enter URL → connects and lists models
- [ ] `guard-sh provider add` → enter unreachable URL → re-prompts
- [ ] `guard-sh provider add` → enter URL without `http://` → auto-prefixed
- [ ] `guard-sh healthcheck` → ollama row shows ok/latency or error
- [ ] `guard-sh check "rm -rf /"` with ollama as first provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)