### PR TITLE
feat: add provider-specific prompt support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ guard-sh status                 show session/global state, config, timeout, cach
 guard-sh check "<cmd>"          core check — exit 0 if safe, exit 1 with warning if risky
 guard-sh check "<cmd>" --debug  trace whitelist hit, cache hit, provider attempts, LLM response
 guard-sh healthcheck            validate API keys, models, latency, shell integration
-guard-sh provider add           interactive: pick provider, enter API key, pick model
+guard-sh provider add           interactive: pick provider, enter API key (or URL for ollama), pick model
 guard-sh provider remove        interactive: remove a configured provider
 guard-sh provider order         interactive TUI: reorder providers with arrow keys
 guard-sh whitelist              list all whitelisted commands
@@ -81,6 +81,8 @@ shell command typed
 
 `prompt.txt` is embedded in the binary and also copied to `~/.config/guard-sh/prompt.txt` at install time. Editing the file on disk takes effect immediately without rebuilding. The LLM is told to reply with `"OK"` for safe commands or a short plain-text warning (no markdown) for risky ones.
 
+Provider-specific prompts can be placed at `~/.config/guard-sh/prompt_PROVIDERNAME.txt` (e.g. `prompt_ollama.txt`). If present, the provider-specific file takes precedence over `prompt.txt` for that provider. Loading happens in `main.go` and is passed to `llm.Multi` as a `map[string]string`.
+
 ### Runtime config location
 
-`~/.config/guard-sh/config.yaml` — providers, API keys, whitelist, cache settings, timeout. See `config.example.yaml` for all options.
+`~/.config/guard-sh/config.yaml` — providers, API keys, whitelist, cache settings, timeout. See `config.default.yaml` (embedded in binary) for all options.

--- a/README.org
+++ b/README.org
@@ -141,6 +141,18 @@ cache_max_size: 1000
 
 The LLM prompt is stored at =~/.config/guard-sh/prompt.txt=. Edit it to adjust what guard-sh considers risky, change the output format, or add your own rules. Changes take effect immediately — no rebuild needed.
 
+** Provider-specific prompts
+
+To use a different prompt for a specific provider, create =prompt_PROVIDERNAME.txt= in the same directory:
+
+#+begin_src bash
+~/.config/guard-sh/prompt.txt           # default, used by all providers
+~/.config/guard-sh/prompt_ollama.txt    # used only when ollama is queried
+~/.config/guard-sh/prompt_gemini.txt    # used only when gemini is queried
+#+end_src
+
+If a provider-specific file exists, it takes precedence over =prompt.txt= for that provider.
+
 * Usage
   :PROPERTIES:
   :CUSTOM_ID: usage
@@ -188,7 +200,7 @@ guard-sh healthcheck
 
 Checks all configured providers without spending any tokens. Reports:
 
-- API key and model validity for each provider
+- API key and model validity for cloud providers; server connectivity for Ollama
 - Response latency per provider
 - Shell integration status (~.bashrc~ / ~.zshrc~)
 - Config errors (e.g. unknown provider names in ~provider_order~)
@@ -197,9 +209,10 @@ Checks all configured providers without spending any tokens. Reports:
   guard-sh healthcheck
 
   providers
-  openai      gpt-4o-mini                          ● ok  (759ms)
+  ollama      llama3.2                             ● ok  (12ms)
   gemini      gemini-3.1-flash-lite-preview        ● ok  (184ms)
   deepseek    deepseek-chat                        ✗ HTTP 401: Authentication Fails
+  openai      gpt-4o-mini                          ● ok  (759ms)
   claude      claude-haiku-4-5-20251001            ● ok  (510ms)
 
   shell
@@ -228,10 +241,11 @@ Shows session and global state, prompt path, timeout, cache stats, active provid
             42 entries, 8.3 KB
 
   providers
-  1  openai    gpt-4o-mini
-  2  gemini    gemini-3.1-flash-lite-preview
+  1  gemini    gemini-3.1-flash-lite-preview
+  2  ollama    llama3.2
   3  deepseek  deepseek-chat
-  4  claude    claude-haiku-4-5-20251001
+  4  openai    gpt-4o-mini
+  5  claude    claude-haiku-4-5-20251001
 
   whitelist
   1  ls

--- a/help.go
+++ b/help.go
@@ -53,7 +53,9 @@ func runHelp() {
 
 	// Config
 	fmt.Printf("  %s\n", b("config"))
-	fmt.Printf("  %s\n\n", d("~/.config/guard-sh/config.yaml — providers, API keys, whitelist, cache, timeout"))
+	fmt.Printf("  %s\n", d("~/.config/guard-sh/config.yaml — providers, API keys, whitelist, cache, timeout"))
+	fmt.Printf("  %s\n", d("~/.config/guard-sh/prompt.txt — default system prompt (edit without rebuild)"))
+	fmt.Printf("  %s\n\n", d("~/.config/guard-sh/prompt_<provider>.txt — per-provider prompt override"))
 
 	// Setup
 	fmt.Printf("  %s\n", b("setup"))

--- a/internal/llm/multi.go
+++ b/internal/llm/multi.go
@@ -22,21 +22,26 @@ const (
 type Multi struct {
 	providers []guard.Provider
 	names     []string
+	prompts   map[string]string // per-provider prompt overrides
 	debug     io.Writer
 }
 
-func NewMulti(names []string, providers []guard.Provider, debug io.Writer) *Multi {
-	return &Multi{names: names, providers: providers, debug: debug}
+func NewMulti(names []string, providers []guard.Provider, prompts map[string]string, debug io.Writer) *Multi {
+	return &Multi{names: names, providers: providers, prompts: prompts, debug: debug}
 }
 
 func (m *Multi) Query(ctx context.Context, systemPrompt, command string) (string, error) {
 	for i, p := range m.providers {
 		name := m.names[i]
+		prompt := systemPrompt
+		if override, ok := m.prompts[name]; ok {
+			prompt = override
+		}
 		if m.debug != nil {
 			fmt.Fprintf(m.debug, "  %s%-10s%s", dbgCyan, name, dbgReset)
 		}
 		start := time.Now()
-		result, err := p.Query(ctx, systemPrompt, command)
+		result, err := p.Query(ctx, prompt, command)
 		elapsed := time.Since(start).Milliseconds()
 		if err == nil {
 			if m.debug != nil {

--- a/internal/llm/multi_test.go
+++ b/internal/llm/multi_test.go
@@ -22,7 +22,7 @@ func (m *mockProvider) Query(_ context.Context, _, _ string) (string, error) {
 func TestMulti_FirstProviderSucceeds(t *testing.T) {
 	p1 := &mockProvider{response: "OK"}
 	p2 := &mockProvider{response: "fallback"}
-	m := NewMulti([]string{"p1", "p2"}, []guard.Provider{p1, p2}, nil)
+	m := NewMulti([]string{"p1", "p2"}, []guard.Provider{p1, p2}, nil, nil)
 
 	result, err := m.Query(context.Background(), "", "ls")
 	if err != nil {
@@ -42,7 +42,7 @@ func TestMulti_FirstProviderSucceeds(t *testing.T) {
 func TestMulti_FallbackOnError(t *testing.T) {
 	p1 := &mockProvider{err: errors.New("rate limit")}
 	p2 := &mockProvider{response: "Deletes everything"}
-	m := NewMulti([]string{"p1", "p2"}, []guard.Provider{p1, p2}, nil)
+	m := NewMulti([]string{"p1", "p2"}, []guard.Provider{p1, p2}, nil, nil)
 
 	result, err := m.Query(context.Background(), "", "rm -rf /")
 	if err != nil {
@@ -62,7 +62,7 @@ func TestMulti_FallbackOnError(t *testing.T) {
 func TestMulti_AllFail(t *testing.T) {
 	p1 := &mockProvider{err: errors.New("error 1")}
 	p2 := &mockProvider{err: errors.New("error 2")}
-	m := NewMulti([]string{"p1", "p2"}, []guard.Provider{p1, p2}, nil)
+	m := NewMulti([]string{"p1", "p2"}, []guard.Provider{p1, p2}, nil, nil)
 
 	_, err := m.Query(context.Background(), "", "rm -rf /")
 	if err == nil {
@@ -74,7 +74,7 @@ func TestMulti_AllFail(t *testing.T) {
 }
 
 func TestMulti_EmptyProviders(t *testing.T) {
-	m := NewMulti(nil, nil, nil)
+	m := NewMulti(nil, nil, nil, nil)
 	_, err := m.Query(context.Background(), "", "ls")
 	if err == nil {
 		t.Error("expected error with no providers, got nil")

--- a/main.go
+++ b/main.go
@@ -365,7 +365,15 @@ func main() {
 	if cfg.CacheEnabled == nil || *cfg.CacheEnabled {
 		cacheMaxSize = cfg.CacheMaxSize
 	}
-	g := guard.New(llm.NewMulti(names, providers, debugOut), defaultPrompt, config.Dir(), cfg.CommandWhitelist, cacheMaxSize, debugOut)
+	providerPrompts := make(map[string]string)
+	for _, name := range names {
+		path := config.Dir() + "/prompt_" + name + ".txt"
+		if data, err := os.ReadFile(path); err == nil {
+			providerPrompts[name] = string(data)
+		}
+	}
+
+	g := guard.New(llm.NewMulti(names, providers, providerPrompts, debugOut), defaultPrompt, config.Dir(), cfg.CommandWhitelist, cacheMaxSize, debugOut)
 
 	timeout := cfg.TimeoutSeconds
 	if timeout <= 0 {


### PR DESCRIPTION
## Summary

- **Provider-specific prompts**: Create `prompt_<provider>.txt` in `~/.config/guard-sh/` to override the system prompt for a specific provider. If the file exists, it takes precedence over `prompt.txt` for that provider only. All other providers continue using `prompt.txt`.
  - Example: `prompt_ollama.txt` for a lighter prompt tuned for smaller local models
  - Loading happens at startup in `main.go`; passed to `llm.Multi` as a `map[string]string`
- **`guard-sh help`**: Config section now documents `prompt.txt` and `prompt_<provider>.txt`
- **README**: Provider-specific prompts section added under Configuration; healthcheck and status examples updated to include Ollama
- **CLAUDE.md**: Fixed stale `config.example.yaml` reference → `config.default.yaml`

## Changed files

| File | Change |
|------|--------|
| `main.go` | Load `prompt_<provider>.txt` files at startup, pass to `llm.NewMulti` |
| `internal/llm/multi.go` | Accept `prompts map[string]string`; use per-provider prompt in `Query()` |
| `internal/llm/multi_test.go` | Update `NewMulti` call signature |
| `help.go` | Document prompt files in config section |
| `README.org` | Provider-specific prompts section; updated examples |
| `CLAUDE.md` | Fix config file reference; document new prompt behaviour |

## Test plan

- [ ] Create `~/.config/guard-sh/prompt_gemini.txt` with custom content → `guard-sh check "rm -rf /" --debug` shows gemini using the custom prompt
- [ ] Without `prompt_gemini.txt`, gemini falls back to `prompt.txt`
- [ ] Other providers unaffected when only one provider-specific file exists
- [ ] `guard-sh help` shows prompt file paths under config section

🤖 Generated with [Claude Code](https://claude.com/claude-code)