### PR TITLE
ci: bump release version to v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,15 @@ jobs:
         run: |
           LATEST=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
           if [ -z "$LATEST" ]; then
-            NEXT="v0.1.0"
+            NEXT="v1.0.0"
           else
             IFS='.' read -r MAJOR MINOR PATCH <<< "${LATEST#v}"
-            NEXT="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+            # If current latest is pre-1.0.0, jump straight to v1.0.0
+            if [ "$MAJOR" -lt 1 ]; then
+              NEXT="v1.0.0"
+            else
+              NEXT="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+            fi
           fi
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

- Release workflow now produces `v1.0.0` instead of `v0.5.4` when the latest tag has major version < 1
- Subsequent releases will continue from `v1.0.1`, `v1.0.2`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)